### PR TITLE
Add args argument before file name

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -20,7 +20,7 @@ class Ghdl(Linter):
 
     """Provides an interface to ghdl."""
 
-    cmd = 'ghdl -a ${file}'
+    cmd = 'ghdl -a ${args} ${file}'
     error_stream = util.STREAM_BOTH
     on_stderr = None
     defaults = {


### PR DESCRIPTION
Add the ${args} argument before the file name in so that arguments stated in linter settnigs are correctly executed in GHDL. Before, arguments are executed after the filename, preventing them to work properly.