### PR TITLE
Update to use the syntax check command

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -20,7 +20,7 @@ class Ghdl(Linter):
 
     """Provides an interface to ghdl."""
 
-    cmd = 'ghdl -a ${args} ${file}'
+    cmd = 'ghdl -s ${args} ${file}'
     error_stream = util.STREAM_BOTH
     on_stderr = None
     defaults = {


### PR DESCRIPTION
This tells GHDL to analyze the file, but not to generate output.

This update allows one to use ghdl 1.0 without generating .o
files for every vhdl file that is checked.